### PR TITLE
feat(java-dsl): Generate constructor documentation

### DIFF
--- a/libs/java-ast/src/lib/ast/Class.spec.ts
+++ b/libs/java-ast/src/lib/ast/Class.spec.ts
@@ -102,6 +102,83 @@ describe("Class", () => {
     expect(output).toContain("this.id = id;");
   });
 
+  it("should write constructor documentation if the constructor has it", () => {
+    const cls = new Class({
+      name: "ClassWithConstructor",
+      packageName: "com.example",
+      access: Access.Public,
+    });
+
+    cls.addConstructor({
+      access: Access.Public,
+      javadoc: "Some constructor",
+      parameters: [
+        new Parameter({
+          name: "id",
+          docs: "The id to set",
+          type: Type.long(),
+        }),
+      ],
+      body: new CodeBlock({ code: "this.id = id;" }),
+    });
+
+    cls.write(writer);
+    const output = writer.toString();
+
+    expect(output).toContain(" * Some constructor");
+    expect(output).toContain(" * @param id The id to set");
+  });
+
+  it("should write constructor documentation if the constructor doesn't, but the parameters do", () => {
+    const cls = new Class({
+      name: "ClassWithConstructor",
+      packageName: "com.example",
+      access: Access.Public,
+    });
+
+    cls.addConstructor({
+      access: Access.Public,
+      parameters: [
+        new Parameter({
+          name: "id",
+          docs: "The id to set",
+          type: Type.long(),
+        }),
+      ],
+      body: new CodeBlock({ code: "this.id = id;" }),
+    });
+
+    cls.write(writer);
+    const output = writer.toString();
+
+    expect(output).toContain(" * @param id The id to set");
+  });
+
+  it("should write constructor documentation if the constructor does but the parameters don't", () => {
+    const cls = new Class({
+      name: "ClassWithConstructor",
+      packageName: "com.example",
+      javadoc: "Some constructor",
+      access: Access.Public,
+    });
+
+    cls.addConstructor({
+      access: Access.Public,
+      parameters: [
+        new Parameter({
+          name: "id",
+          type: Type.long(),
+        }),
+      ],
+      body: new CodeBlock({ code: "this.id = id;" }),
+    });
+
+    cls.write(writer);
+    const output = writer.toString();
+
+    expect(output).toContain(" * Some constructor");
+  });
+
   it("should write a class with inheritance", () => {
     const cls = new Class({
       name: "Child",

--- a/libs/java-ast/src/lib/ast/Class.ts
+++ b/libs/java-ast/src/lib/ast/Class.ts
@@ -58,6 +58,8 @@ export declare namespace Class {
     parameters: Parameter[];
     /** The access level of the constructor */
     access: Access;
+    /** Documentation/JavaDoc for the constructor */
+    javadoc?: string;
     /** Constructor annotations */
     annotations?: Annotation[];
     /** Whether this constructor calls another constructor with super() */
@@ -316,6 +318,25 @@ export class Class extends AstNode {
     writer: Writer,
     constructor: Class.Constructor,
   ): void {
+    // Write JavaDoc if provided
+    if (
+      constructor.javadoc ||
+      constructor.parameters.some((param) => param.docs)
+    ) {
+      writer.writeLine("/**");
+      if (constructor.javadoc) {
+        constructor.javadoc.split("\n").forEach((line) => {
+          writer.writeLine(` * ${line}`);
+        });
+      }
+      constructor.parameters.forEach((param) => {
+        if (param.docs) {
+          writer.writeLine(` * @param ${param.name} ${param.docs}`);
+        }
+      });
+      writer.writeLine(" */");
+    }
+
     // Write annotations
     if (constructor.annotations) {
       constructor.annotations.forEach((annotation) => {


### PR DESCRIPTION
Fixes: amplication/amplication#9844

## PR Details

This PR adds support for generating constructor documentation for Java. 

* It uses the existing `docs` property for the parameters
* It adds an optional `javadoc` property to the `Constructor` type (the naming is consistent with the `Class` properties which also use `javadoc`)
* Tests are added for cases where parameters are documented but the constructor isn't, where the constructor is documented but the parameters aren't, and where both are documented 

## PR Checklist

- [x] Tests for the changes have been added
- [x] `npm test` doesn't throw any error

IMPORTANT: Please review the [CONTRIBUTING.md](https://github.com/amplication/amplication/blob/master/CODE_OF_CONDUCT.md) file for detailed contributing guidelines.
